### PR TITLE
Create calibreapp-image-actions.yml

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -1,0 +1,56 @@
+# Image Actions will run in the following scenarios:
+# - on Pull Requests containing images (not including forks)
+# - on pushing of images to `main` (for forks)
+# - on demand (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
+# - at 11 PM every Sunday in anything gets missed with any of the above scenarios
+# For Pull Requests, the images are added to the PR.
+# For other scenarios, a new PR will be opened if any images are compressed.
+name: Compress images
+on:
+  pull_request:
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+  workflow_dispatch:
+  schedule:
+    - cron: '00 23 * * 0'
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    # Only run on main repo on and PRs that match the main repo.
+    if: |
+      github.repository == 'example/example_repo' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # For non-Pull Requests, run in compressOnly mode and we'll PR after.
+          compressOnly: ${{ github.event_name != 'pull_request' }}
+      - name: Create Pull Request
+        # If it's not a Pull Request then commit any changes as a new PR.
+        if: |
+          github.event_name != 'pull_request' &&
+          steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Auto Compress Images
+          branch-suffix: timestamp
+          commit-message: Compress Images
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
Issue: [#2](https://github.com/MLH-Fellowship/prep-portfolio-22.JUL.PREP.2/issues/2)

Used [Github Image Actions](https://github.com/marketplace/actions/image-actions) to optimize images

Added .github/workflows/calibreapp-image-actions.yml in the repository

Image Actions will compress images so that they’re smaller, every time we push an image in the main branch,

We can control the quality of the images, we have kept it to default as of now

Image Actions adds optimized images to the current Pull Request and posts a summary comment.

Image Actions will run in the following scenarios:
on Pull Requests containing images (not including forks)
on pushing of images to main (for forks)

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.



